### PR TITLE
examples: make sample scripts cwd-independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ This toolkit includes software developed by Members of the Geant4 Collaboration 
 
 For more information such as installation, examples, please visit: [github.com/xcist/documentation/wiki/Home](https://github.com/xcist/documentation/wiki)
 
+Example scripts under [gecatsim/examples](gecatsim/examples) now resolve their config and local data paths relative to the script file, so they can be launched from the repository root or any other working directory.
+
 Please consider citing our papers if this package is useful to your research/work. A list of our publications is here: https://github.com/xcist/documentation/wiki/Publications-and-citing

--- a/gecatsim/examples/Sim_Recon_Sample.py
+++ b/gecatsim/examples/Sim_Recon_Sample.py
@@ -1,6 +1,9 @@
 # Copyright 2024, GE Precision HealthCare. All rights reserved. See https://github.com/xcist/main/tree/master/license
 
 ###------------ import XCIST-CatSim
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import gecatsim as xc
 import gecatsim.reconstruction.pyfiles.recon as recon
 
@@ -10,7 +13,12 @@ import gecatsim.reconstruction.pyfiles.recon as recon
 # add any additional search directories
 #my_path.add_search_path("my-experiments")
 
-ct = xc.CatSim("./cfg/Phantom_Sample", "./cfg/Scanner_Sample_generic", "./cfg/Protocol_Sample_axial")  # initialization
+example_dir = os.path.dirname(os.path.abspath(__file__))
+ct = xc.CatSim(
+	os.path.join(example_dir, "cfg", "Phantom_Sample"),
+	os.path.join(example_dir, "cfg", "Scanner_Sample_generic"),
+	os.path.join(example_dir, "cfg", "Protocol_Sample_axial"),
+)  # initialization
 
 ##--------- Make changes to parameters (optional)
 ct.resultsName = "test"

--- a/gecatsim/examples/Sim_Recon_Sample_PCCT.py
+++ b/gecatsim/examples/Sim_Recon_Sample_PCCT.py
@@ -4,6 +4,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 ###------------ import XCIST-CatSim
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import gecatsim as xc
 import gecatsim.reconstruction.pyfiles.recon as recon
 
@@ -12,7 +15,12 @@ import gecatsim.reconstruction.pyfiles.recon as recon
 # add any additional search directories
 #my_path.add_search_path("my-experiments")
 
-ct = xc.CatSim("./cfg/Phantom_Sample", "./cfg/Scanner_PCCT", "./cfg/Physics_Sample")  # initialization
+example_dir = os.path.dirname(os.path.abspath(__file__))
+ct = xc.CatSim(
+    os.path.join(example_dir, "cfg", "Phantom_Sample"),
+    os.path.join(example_dir, "cfg", "Scanner_PCCT"),
+    os.path.join(example_dir, "cfg", "Physics_Sample"),
+)  # initialization
 
 ##--------- Make changes to parameters (optional)
 ct.resultsName = "test"

--- a/gecatsim/examples/Sim_Sample.py
+++ b/gecatsim/examples/Sim_Sample.py
@@ -1,6 +1,10 @@
 # Copyright 2024, GE Precision HealthCare. All rights reserved. See https://github.com/xcist/main/tree/master/license
 
 ###------------ import XCIST-CatSim
+# import the package from the current directory (instead of the installed package) to ensure the latest code is used
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))  # add the parent directory of the current file to the search path
 import gecatsim as xc
 
 
@@ -9,7 +13,12 @@ import gecatsim as xc
 # add any additional search directories
 #my_path.add_search_path("my-experiments")
 
-ct = xc.CatSim("./cfg/Phantom_Sample", "./cfg/Scanner_Sample_generic", "./cfg/Protocol_Sample_axial")  # initialization
+example_dir = os.path.dirname(os.path.abspath(__file__))
+ct = xc.CatSim(
+	os.path.join(example_dir, "cfg", "Phantom_Sample"),
+	os.path.join(example_dir, "cfg", "Scanner_Sample_generic"),
+	os.path.join(example_dir, "cfg", "Protocol_Sample_axial"),
+)  # initialization
 
 ##--------- Make changes to parameters (optional)
 ct.resultsName = "test"

--- a/gecatsim/examples/Sim_Sample_Analyic.py
+++ b/gecatsim/examples/Sim_Sample_Analyic.py
@@ -1,10 +1,14 @@
 # Copyright 2024, GE Precision HealthCare. All rights reserved. See https://github.com/xcist/main/tree/master/license
 
 ###------------ import XCIST-CatSim
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import gecatsim as xc
 
 ##--------- Initialize 
-ct = xc.CatSim("./cfg/Phantom_Sample_Analytic")  # initialization
+example_dir = os.path.dirname(os.path.abspath(__file__))
+ct = xc.CatSim(os.path.join(example_dir, "cfg", "Phantom_Sample_Analytic"))  # initialization
 
 ##--------- Make changes to parameters (optional)
 # ct.phantom.filename = 'water20.ppm'

--- a/gecatsim/examples/Sim_Sample_Helical.py
+++ b/gecatsim/examples/Sim_Sample_Helical.py
@@ -1,15 +1,19 @@
 # Copyright 2024, GE Precision HealthCare. All rights reserved. See https://github.com/xcist/main/tree/master/license
 
 ###------------ import XCIST-CatSim
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import gecatsim as xc
 from gecatsim.reconstruction.pyfiles import recon
 
 ##--------- Initialize 
-ct = xc.CatSim("./cfg/Phantom_Sample_Analytic",
-               "./cfg/Protocol_Sample_Helical",
-               "./cfg/Scanner_Sample_generic",
-               "./cfg/Physics_Sample",
-               "./cfg/Recon_Sample_Helical",
+example_dir = os.path.dirname(os.path.abspath(__file__))
+ct = xc.CatSim(os.path.join(example_dir, "cfg", "Phantom_Sample_Analytic"),
+                 os.path.join(example_dir, "cfg", "Protocol_Sample_Helical"),
+                 os.path.join(example_dir, "cfg", "Scanner_Sample_generic"),
+                 os.path.join(example_dir, "cfg", "Physics_Sample"),
+                 os.path.join(example_dir, "cfg", "Recon_Sample_Helical"),
 
         )  # initialization
 

--- a/gecatsim/examples/Sim_Sample_Hybrid.py
+++ b/gecatsim/examples/Sim_Sample_Hybrid.py
@@ -1,10 +1,14 @@
 # Copyright 2024, GE Precision HealthCare. All rights reserved. See https://github.com/xcist/main/tree/master/license
 
 ###------------ import XCIST-CatSim
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import gecatsim as xc
 
 ##--------- Initialize 
-ct = xc.CatSim("./cfg/Phantom_Sample_Hybrid")  # initialization
+example_dir = os.path.dirname(os.path.abspath(__file__))
+ct = xc.CatSim(os.path.join(example_dir, "cfg", "Phantom_Sample_Hybrid"))  # initialization
 
 ##--------- Make changes to parameters (optional)
 

--- a/gecatsim/examples/Sim_Sample_PCCT.py
+++ b/gecatsim/examples/Sim_Sample_PCCT.py
@@ -1,6 +1,9 @@
 # Copyright 2024, GE Precision HealthCare. All rights reserved. See https://github.com/xcist/main/tree/master/license
 
 ###------------ import XCIST-CatSim
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import gecatsim as xc
 import gecatsim.reconstruction.pyfiles.recon as recon
 from gecatsim.pyfiles.CommonTools import *
@@ -10,7 +13,13 @@ from gecatsim.pyfiles.CommonTools import *
 #my_path = xc.pyfiles.CommonTools.my_path
 #my_path.add_search_path("my-experiments")
 
-ct = xc.CatSim("./cfg/Scanner_PCCT", "./cfg/Phantom_Sample", "./cfg/Protocol_Sample_axial",'./cfg/Physics_Sample')  # initialization
+example_dir = os.path.dirname(os.path.abspath(__file__))
+ct = xc.CatSim(
+    os.path.join(example_dir, "cfg", "Scanner_PCCT"),
+    os.path.join(example_dir, "cfg", "Phantom_Sample"),
+    os.path.join(example_dir, "cfg", "Protocol_Sample_axial"),
+    os.path.join(example_dir, "cfg", "Physics_Sample"),
+)  # initialization
 
 ##--------- PCCT
 ct.scanner.detectorMaterial = "CZT"            # detector sensor material

--- a/gecatsim/examples/Sim_Sample_Polygonal.py
+++ b/gecatsim/examples/Sim_Sample_Polygonal.py
@@ -1,17 +1,21 @@
 # Copyright 2024, GE Precision HealthCare. All rights reserved. See https://github.com/xcist/main/tree/master/license
 
 ###------------ import XCIST-CatSim
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import numpy as np
 import gecatsim as xc
 import gecatsim.reconstruction.pyfiles.recon as recon
 
 ##--------- Initialize
-ct = xc.CatSim("./cfg/Phantom_Sample_Polygonal")  # initialization
+example_dir = os.path.dirname(os.path.abspath(__file__))
+ct = xc.CatSim(os.path.join(example_dir, "cfg", "Phantom_Sample_Polygonal"))  # initialization
 
 ##--------- Make changes to parameters (optional)
 ct.resultsName = "test_Polygonal"
 
-ct.phantom.filename = '../phantom/female_adult_average_lung_lesions_reduced.nrb'
+ct.phantom.filename = os.path.join(example_dir, "..", "phantom", "female_adult_average_lung_lesions_reduced.nrb")
 
 # Here the phantom position and scaling are only for illustrating purpose due to the object's small size.
 ct.phantom.centerOffset = [54, 51, -102]      # offset of phantom center relative to origin (in mm)

--- a/gecatsim/examples/Sim_Sample_XCAT.py
+++ b/gecatsim/examples/Sim_Sample_XCAT.py
@@ -1,17 +1,21 @@
 # Copyright 2024, GE Precision HealthCare. All rights reserved. See https://github.com/xcist/main/tree/master/license
 
 ###------------ import XCIST-CatSim
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import numpy as np
 import gecatsim as xc
 import gecatsim.reconstruction.pyfiles.recon as recon
 
 ##--------- Initialize 
-ct = xc.CatSim("./cfg/Phantom_Sample_XCAT")  # initialization
+example_dir = os.path.dirname(os.path.abspath(__file__))
+ct = xc.CatSim(os.path.join(example_dir, "cfg", "Phantom_Sample_XCAT"))  # initialization
 
 ##--------- Make changes to parameters (optional)
 ct.resultsName = "test_XCAT"
 
-ct.phantom.filename = '../phantom/vmale50_chest_less_surfaces.nrb'
+ct.phantom.filename = os.path.join(example_dir, "..", "phantom", "vmale50_chest_less_surfaces.nrb")
 
 ct.protocol.viewsPerRotation = 500
 ct.protocol.viewCount = ct.protocol.viewsPerRotation


### PR DESCRIPTION
## Summary

- Makes example scripts runnable from any working directory.
- Resolves config and local data paths relative to each script location.
- Removes cwd-dependent ./cfg and ../phantom assumptions.
## Scope

- Updated example scripts in [Sim_Sample.py]
  - [Sim_Recon_Sample.py]
  - [Sim_Recon_Sample_PCCT.py]
  - [Sim_Sample_PCCT.py]
  - [Sim_Sample_Helical.py]
  - [Sim_Sample_XCAT.py]
  - [Sim_Sample_Hybrid.py]
  - [Sim_Sample_Polygonal.py]
  - [Sim_Sample_Analyic.py]
- Added note in [README.md]
## Verification

- No remaining ./cfg references in example scripts.
- No remaining ../phantom literal references in example scripts.